### PR TITLE
♻️ Refactor: Enhance `DbModel` initialization and MongoDB aggregate pipeline construction

### DIFF
--- a/pyodmongo/services/aggregate_stages.py
+++ b/pyodmongo/services/aggregate_stages.py
@@ -76,7 +76,7 @@ def set_(as_: str):
     return [{"$set": {as_: {"$arrayElemAt": [f"${as_}", 0]}}}]
 
 
-def group_set_replace_root(id_: str, field: str, path_str: str):
+def group_set_replace_root(id_: str, array_index: str, field: str, path_str: str):
     """
     Constructs a combination of group, set, and replaceRoot stages for a MongoDB aggregation pipeline.
 
@@ -101,7 +101,18 @@ def group_set_replace_root(id_: str, field: str, path_str: str):
                 field: {"$push": f"${path_str}"},
             }
         },
-        {"$set": {f"_document.{path_str}": f"${field}"}},
+        # {"$set": {f"_document.{path_str}": f"${field}"}},
+        {
+            "$set": {
+                f"_document.{path_str}": {
+                    "$cond": {
+                        "if": {"$eq": [f"$_document.{array_index}", None]},
+                        "then": None,
+                        "else": f"${field}",
+                    }
+                }
+            }
+        },
         {"$replaceRoot": {"newRoot": "$_document"}},
     ]
 

--- a/pyodmongo/services/reference_pipeline.py
+++ b/pyodmongo/services/reference_pipeline.py
@@ -104,7 +104,7 @@ def resolve_reference_pipeline(
                 "_id" if reverse_index - 1 < 0 else unwind_index_list[reverse_index - 1]
             )
             pipeline += group_set_replace_root(
-                id_=unwind_index, field=path_str.split(".")[-1], path_str=path_str
+                id_=unwind_index, array_index=unwind_index_list[-1], field=path_str.split(".")[-1], path_str=path_str
             )
             pipeline += unset(fields=[unwind_index_list[reverse_index - 1]])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ mkdocs-get-deps==0.2.0
 mkdocs-material==9.5.25
 mkdocs-material-extensions==1.3.1
 mkdocs-static-i18n==1.2.3
-motor==3.4.0
+motor==3.6.0
 mypy-extensions==1.0.0
 orjson==3.10.3
 packaging==24.0
@@ -47,11 +47,11 @@ pillow==10.3.0
 platformdirs==4.2.2
 pluggy==1.5.0
 pycparser==2.22
-pydantic==2.7.4
-pydantic_core==2.18.4
+pydantic==2.9.2
+pydantic_core==2.23.4
 Pygments==2.18.0
 pymdown-extensions==10.8.1
-pymongo==4.7.2
+pymongo==4.9.2
 pyparsing==3.1.2
 pytest==8.2.1
 pytest-asyncio==0.23.7

--- a/tests/test_async_crud_db.py
+++ b/tests/test_async_crud_db.py
@@ -564,7 +564,6 @@ async def test_nested_list_objects(
         attr_3="obj_15", class_two_b=obj_13, class_two_b_list=[obj_13, obj_14]
     )
     await async_engine.save(obj_15)
-
     obj_found = await async_engine.find_one(Model=ClassThree, populate=True)
     assert obj_found.id == obj_15.id
     assert obj_found.class_two_b.attr_2_b == "obj_13"

--- a/tests/test_dict_empty.py
+++ b/tests/test_dict_empty.py
@@ -7,7 +7,7 @@ def test_empty_dict():
         _collection = "my_model_1"
 
     class MyModel2(DbModel):
-        attr2: str | None
+        attr2: str | None = None
         attr2_list: list | None = []
         my_model_1: MyModel1 | Id | None
         _collection = "my_model_2"
@@ -40,9 +40,21 @@ def test_empty_dict():
             "updated_at": None,
             "attr2": "Escrito",
             "attr2_list": [],
-            "my_model_1": None,
+            "my_model_1": {
+                "id": None,
+                "created_at": None,
+                "updated_at": None,
+                "attr1": None,
+            },
         },
-        "my_model_2_2": None,
+        "my_model_2_2": {
+            "attr2": None,
+            "id": None,
+            "created_at": None,
+            "updated_at": None,
+            "my_model_1": None,
+            "attr2_list": None,
+        },
         "my_model_2_3": None,
         "my_model_2_4": {
             "id": None,


### PR DESCRIPTION
Refactor: Enhance `DbModel` initialization and MongoDB aggregate pipeline construction

- Refactored the `__init__` method of `DbModel`:
  - Empty dictionaries are now converted to `None`.
  - Empty dictionaries within lists are removed for better consistency.
- Adjusted the method responsible for constructing the MongoDB aggregate pipeline:
  - Improved handling of `null` values and logical conditions

This refactor enhances data consistency and simplifies downstream processing.