### PR TITLE
🐛 Fix pipeline order in mount_base_pipeline

### DIFF
--- a/pyodmongo/engines/utils.py
+++ b/pyodmongo/engines/utils.py
@@ -154,6 +154,6 @@ def mount_base_pipeline(
         reference_stage = resolve_reference_pipeline(
             cls=Model, pipeline=[], populate_db_fields=populate_db_fields
         )
-        return match_stage + sort_stage + skip_stage + limit_stage + reference_stage
+        return match_stage + reference_stage + sort_stage + skip_stage + limit_stage
     else:
         return match_stage + sort_stage + skip_stage + limit_stage


### PR DESCRIPTION
This PR fixes the pipeline stage ordering in the `mount_base_pipeline` function when `populate=True`. The reference stage was being placed after sort, skip, and limit stages, which could lead to incorrect query results.

## Changes
- Move `reference_stage` to execute before `sort_stage`, `skip_stage`, and `limit_stage` in the pipeline
- This ensures population of references happens before sorting and pagination operations

## Why this matters
The previous order could cause issues when:
- Sorting by fields from populated references
- The populated data affects the sorting